### PR TITLE
Fix Makefiles compilation error on file change

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -42,13 +42,13 @@ build: build-subdir ${objs}
 
 ${builddir}/%.o: %.c
 	@mkdir -p ${builddir}
-	@${CC} ${CFLAGS} -o $@ -c $^
-	@printf "[ \e[32mCC\e[0m ]  %s\n" $^
+	@${CC} ${CFLAGS} -o $@ -c $<
+	@printf "[ \e[32mCC\e[0m ]  %s\n" $<
 
 ${builddir}/%.o: %.s
 	@mkdir -p ${builddir}
-	@${AS} ${ASFLAGS} -o $@ -c $^
-	@printf "[ \e[32mAS\e[0m ]  %s\n" $^
+	@${AS} ${ASFLAGS} -o $@ -c $<
+	@printf "[ \e[32mAS\e[0m ]  %s\n" $<
 
 .PHONY: clean
 clean: clean-subdir

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -34,13 +34,13 @@ build: build-subdir ${objs}
 
 ${builddir}/%.o: %.c
 	@mkdir -p ${builddir}
-	@${CC} ${CFLAGS} -o $@ -c $^
-	@printf "[ \e[32mCC\e[0m ]  %s\n" $^
+	@${CC} ${CFLAGS} -o $@ -c $<
+	@printf "[ \e[32mCC\e[0m ]  %s\n" $<
 
 ${builddir}/%.o: %.s
 	@mkdir -p ${builddir}
-	@${AS} ${ASFLAGS} -o $@ -c $^
-	@printf "[ \e[32mAS\e[0m ]  %s\n" $^
+	@${AS} ${ASFLAGS} -o $@ -c $<
+	@printf "[ \e[32mAS\e[0m ]  %s\n" $<
 
 .PHONY: clean
 clean: clean-subdir

--- a/lib/string/Makefile
+++ b/lib/string/Makefile
@@ -41,13 +41,13 @@ lib: build
 
 ${local-builddir}/%.o: %.c
 	@mkdir -p ${local-builddir}
-	@${CC} ${CFLAGS} -o $@ -c $^
-	@printf "[ \e[32mCC\e[0m ]  %s\n" $^
+	@${CC} ${CFLAGS} -o $@ -c $<
+	@printf "[ \e[32mCC\e[0m ]  %s\n" $<
 
 ${local-builddir}/%.o: %.s
 	@mkdir -p ${local-builddir}
-	@${AS} ${ASFLAGS} -o $@ -c $^
-	@printf "[ \e[32mAS\e[0m ]  %s\n" $^
+	@${AS} ${ASFLAGS} -o $@ -c $<
+	@printf "[ \e[32mAS\e[0m ]  %s\n" $<
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Change the automatic varriables of Makefile from $^ (all dependencies) to $< (first dependencies) to avoid compilation with wrong files.