### PR TITLE
Fix #7: Change clean rule in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,31 @@ boot:
 
 .PHONY: clean
 clean: clean-subdir
-	@${RM} ${builddir}/${kernel}
-	@${RM} ${builddir}/${kernel}.iso
-	@${RM} -r ${isodir}
-	@rmdir --ignore-fail-on-non-empty ${builddir}
-	@printf "[ \e[31mRM\e[0m ]  %s\n" ${kernel}
-	@printf "[ \e[31mRM\e[0m ]  %s\n" ${kernel}.iso
+	@if [ -d ${builddir} ]; then \
+		for obj in $$(find . -type f -name '*.o' | tr '\n' ' '); do \
+			if [ -f $$obj ]; then \
+				${RM} $$obj; \
+				printf "[ \e[31mRM\e[0m ]  %s\n" "$${obj#./build/}"; \
+			fi; \
+		done; \
+		for obj in $$(find . -type f -name '*.a' | tr '\n' ' '); do \
+			if [ -f $$obj ]; then \
+				${RM} $$obj; \
+				printf "[ \e[31mRM\e[0m ]  %s\n" "$${obj#./build/}"; \
+			fi; \
+		done; \
+		${RM} $$(find . -type f -name '*.d'); \
+		${RM} ${builddir}/${kernel}; \
+		${RM} ${builddir}/${kernel}.iso; \
+		${RM} -r ${isodir}; \
+		printf "[ \e[31mRM\e[0m ]  %s\n" ${kernel}; \
+		printf "[ \e[31mRM\e[0m ]  %s\n" ${kernel}.iso; \
+		rmdir --ignore-fail-on-non-empty ${builddir}; \
+	fi
+
+.PHONY: fclean
+fclean: clean
+	@${RM} -r ${builddir}
 
 # SUBDIR
 .PHONY: build-subdir

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -53,12 +53,16 @@ ${builddir}/%.o: %.s
 
 .PHONY: clean
 clean: clean-subdir
-	@${RM} ${objs}
 	@${RM} ${deps}
-	@rmdir --ignore-fail-on-non-empty ${builddir}
-	@for obj in $(foreach o,${objs},$(shell basename ${o})); do \
-		printf "[ \e[31mRM\e[0m ]  %s\n" $$obj; \
-	done
+	@if [ -d ${builddir} ]; then \
+		for obj in ${objs}; do \
+			if [ -f $$obj ]; then \
+				${RM} $$obj; \
+				printf "[ \e[31mRM\e[0m ]  %s\n" "$${obj#${builddir}/}"; \
+			fi; \
+		done; \
+		rmdir --ignore-fail-on-non-empty ${builddir}; \
+	fi
 
 # SUBDIR
 .PHONY: build-subdir

--- a/kernel/keyboard/Makefile
+++ b/kernel/keyboard/Makefile
@@ -51,12 +51,16 @@ ${builddir}/%.o: %.s
 
 .PHONY: clean
 clean: clean-subdir
-	@${RM} ${objs}
 	@${RM} ${deps}
-	@rmdir --ignore-fail-on-non-empty ${builddir}
-	@for obj in $(foreach o,${objs},$(shell basename ${o})); do \
-		printf "[ \e[31mRM\e[0m ]  %s\n" $$obj; \
-	done
+	@if [ -d ${builddir} ]; then \
+		for obj in ${objs}; do \
+			if [ -f $$obj ]; then \
+				${RM} $$obj; \
+				printf "[ \e[31mRM\e[0m ]  %s\n" "$${obj#${builddir}/}"; \
+			fi; \
+		done; \
+		rmdir --ignore-fail-on-non-empty ${builddir}; \
+	fi
 
 # SUBDIR
 .PHONY: build-subdir

--- a/kernel/keyboard/keymaps/Makefile
+++ b/kernel/keyboard/keymaps/Makefile
@@ -50,12 +50,16 @@ ${builddir}/%.o: %.s
 
 .PHONY: clean
 clean: clean-subdir
-	@${RM} ${objs}
 	@${RM} ${deps}
-	@rmdir --ignore-fail-on-non-empty ${builddir}
-	@for obj in $(foreach o,${objs},$(shell basename ${o})); do \
-		printf "[ \e[31mRM\e[0m ]  %s\n" $$obj; \
-	done
+	@if [ -d ${builddir} ]; then \
+		for obj in ${objs}; do \
+			if [ -f $$obj ]; then \
+				${RM} $$obj; \
+				printf "[ \e[31mRM\e[0m ]  %s\n" "$${obj#${builddir}/}"; \
+			fi; \
+		done; \
+		rmdir --ignore-fail-on-non-empty ${builddir}; \
+	fi
 
 # SUBDIR
 .PHONY: build-subdir

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -44,10 +44,16 @@ ${builddir}/%.o: %.s
 
 .PHONY: clean
 clean: clean-subdir
-	@${RM} ${objs}
-	@for obj in $(foreach o,${objs},$(shell basename ${o})); do \
-		printf "[ \e[31mRM\e[0m ]  %s\n" $$obj; \
-	done
+	@${RM} ${deps}
+	@if [ -d ${builddir} ]; then \
+		for obj in ${objs}; do \
+			if [ -f $$obj ]; then \
+				${RM} $$obj; \
+				printf "[ \e[31mRM\e[0m ]  %s\n" "$${obj#${builddir}/}"; \
+			fi; \
+		done; \
+		rmdir --ignore-fail-on-non-empty ${builddir}; \
+	fi
 
 # SUBDIR
 .PHONY: build-subdir

--- a/lib/string/Makefile
+++ b/lib/string/Makefile
@@ -24,7 +24,7 @@ objs:= $(addprefix ${local-builddir}/, ${src-y})
 objs:= ${objs:.c=.o}
 objs:= ${objs:.s=.o}
 
-deps:= ${objs::o=.b}
+deps:= ${objs:.o=.d}
 -include ${defs}
 
 # RULES
@@ -51,10 +51,20 @@ ${local-builddir}/%.o: %.s
 
 .PHONY: clean
 clean:
-	@${RM} ${objs}
-	@${RM} ${builddir}/lib${libname}.a
-	@${RM} -r ${local-builddir}
-	@for obj in $(foreach o,${objs},$(shell basename ${o})); do \
-		printf "[ \e[31mRM\e[0m ]  %s\n" $$obj; \
-	done
-	@printf "[ \e[31mRM\e[0m ]  %s\n" $(shell basename ${builddir}/lib${libname}.a)
+	@${RM} ${deps}
+	@if [ -d ${local-builddir} ]; then \
+		for obj in ${objs}; do \
+			if [ -f $(shell pwd)/$$obj ]; then \
+				${RM} $$obj; \
+				printf "[ \e[31mRM\e[0m ]  %s\n" "$${obj#${local-builddir}/}"; \
+			fi; \
+		done; \
+		${RM} -r ${local-builddir}; \
+	fi
+	@if [ -d ${builddir} ]; then \
+		if [ -f ${builddir}/lib${libname}.a ]; then \
+			${RM} ${builddir}/lib${libname}.a; \
+			printf "[ \e[31mRM\e[0m ]  %s\n" $(shell basename ${builddir}/lib${libname}.a); \
+		fi; \
+		rmdir --ignore-fail-on-non-empty ${builddir}; \
+	fi


### PR DESCRIPTION
Check if builddir is present before try to remove. Check in sub Makefile to remove and print only present obj file built by this Makefile.
In main Makefile remove all objects, libraries and dependencies files not removed by other Makefile.

Closes #7 