### PR TITLE
Update instructions in load and reset stack

### DIFF
--- a/kernel/idt_internal.h
+++ b/kernel/idt_internal.h
@@ -6,7 +6,7 @@
  * Declaration of idt internal structures and functions.
  *
  * created: 2022/10/18 - xlmod <glafond-@student.42.fr>
- * updated: 2022/10/20 - mrxx0 <chcoutur@student.42.fr>
+ * updated: 2022/10/21 - mrxx0 <chcoutur@student.42.fr>
  */
 
 #ifndef IDT_INTERNAL_H
@@ -32,12 +32,14 @@
 			"mov %ax, %es\n"\
 			"mov %ax, %fs\n"\
 			"mov %ax, %gs\n"\
+			"add $4, %esp\n"\
 			)
 
 /* Macro to reset the segment registers to their original values.
  */
 #define RESET_INTERRUPT_STACK \
 	__asm__ volatile (\
+			"sub $4, %esp\n"\
 			"pop %eax\n"\
 			"mov %ax, %ds\n"\
 			"mov %ax, %es\n"\

--- a/kernel/idt_internal.h
+++ b/kernel/idt_internal.h
@@ -6,7 +6,7 @@
  * Declaration of idt internal structures and functions.
  *
  * created: 2022/10/18 - xlmod <glafond-@student.42.fr>
- * updated: 2022/10/19 - lfalkau <lfalkau@student.42.fr>
+ * updated: 2022/10/20 - mrxx0 <chcoutur@student.42.fr>
  */
 
 #ifndef IDT_INTERNAL_H
@@ -32,23 +32,19 @@
 			"mov %ax, %es\n"\
 			"mov %ax, %fs\n"\
 			"mov %ax, %gs\n"\
-			"mov %ax, %ss\n"\
-			"add $4, %esp\n"\
 			)
 
 /* Macro to reset the segment registers to their original values.
  */
 #define RESET_INTERRUPT_STACK \
 	__asm__ volatile (\
-			"sub $4, %esp\n"\
 			"pop %eax\n"\
-			"mov %ds, %ax\n"\
-			"mov %es, %ax\n"\
-			"mov %fs, %ax\n"\
-			"mov %gs, %ax\n"\
-			"mov %ss, %ax\n"\
-			"sti\n")
-
+			"mov %ax, %ds\n"\
+			"mov %ax, %es\n"\
+			"mov %ax, %fs\n"\
+			"mov %ax, %gs\n"\
+			"sti\n"\
+			)
 
 /* Entry in the IDT
  */


### PR DESCRIPTION
This update on the instructions is needed to handle properly registers during an interrupt.
We were also printing the interrupt frame between the two state of handling it (loading to the stack and resetting it), this was wrong and caused random value to be printed.