### PR TITLE
Add required C flags (42 subjects)

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -11,7 +11,7 @@ ASFLAGS+=
 AR:= ${cross-target}-ar
 ARFLAGS:= rc
 CC:= ${cross-target}-gcc
-CFLAGS+= -ffreestanding -nostdlib -mgeneral-regs-only -MMD $(addprefix -I, ${.INCLUDE_DIRS})
+CFLAGS+= -ffreestanding -nostdlib -nodefaultlibs -fno-builtin -mgeneral-regs-only -MMD $(addprefix -I, ${.INCLUDE_DIRS})
 LD:= ${cross-target}-ld
 LDFLAGS+=
 

--- a/kernel/keyboard/Makefile
+++ b/kernel/keyboard/Makefile
@@ -11,7 +11,7 @@ ASFLAGS+=
 AR:= ${cross-target}-ar
 ARFLAGS:= rc
 CC:= ${cross-target}-gcc
-CFLAGS+= -ffreestanding -nostdlib -MMD $(addprefix -I, ${.INCLUDE_DIRS})
+CFLAGS+= -ffreestanding -nostdlib -nodefaultlibs -fno-builtin -MMD $(addprefix -I, ${.INCLUDE_DIRS})
 LD:= ${cross-target}-ld
 LDFLAGS+=
 

--- a/kernel/keyboard/keymaps/Makefile
+++ b/kernel/keyboard/keymaps/Makefile
@@ -11,7 +11,7 @@ ASFLAGS+=
 AR:= ${cross-target}-ar
 ARFLAGS:= rc
 CC:= ${cross-target}-gcc
-CFLAGS+= -ffreestanding -nostdlib -MMD $(addprefix -I, ${.INCLUDE_DIRS})
+CFLAGS+= -ffreestanding -nostdlib -nodefaultlibs -fno-builtin -MMD $(addprefix -I, ${.INCLUDE_DIRS})
 LD:= ${cross-target}-ld
 LDFLAGS+=
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -7,7 +7,7 @@ ASFLAGS+=
 AR:= ${cross-target}-ar
 ARFLAGS:= rc
 CC:= ${cross-target}-gcc
-CFLAGS+= -ffreestanding -nostdlib -MMD
+CFLAGS+= -ffreestanding -nostdlib -nodefaultlibs -fno-builtin -MMD
 LD:= ${cross-target}-ld
 LDFLAGS+=
 


### PR DESCRIPTION
-fno-builtin:
   Avoids the auto detection of builtin functions that may
   be asm inlined (Thus no symbol is added to the object file)
   and we can't set a breakpoint on those builtin functions.

-nodefaultstdlib:
   Normally covered by -nostdlib, but 42 requires it!

NOTE: -fno-stack-protector is also required, but the option seems to not exist, and it also seems to be the default behaviour.