### PR TITLE
Implement reboot function through PS/2

### DIFF
--- a/include/kernel/port.h
+++ b/include/kernel/port.h
@@ -17,9 +17,4 @@
 uint8_t		port_read(uint16_t port);
 void		port_write(uint16_t port, uint8_t val);
 
-/* Ports definition */
-
-#define PS2_DATA 0x60
-#define PS2_STATUS_REGISTER 0x64
-
 #endif

--- a/include/kernel/ps2.h
+++ b/include/kernel/ps2.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: CGL-KFS
+// SPDX-License-Identifier: BSD-3-Clause
+
+/* PS/2 controller header file
+ *
+ * Mainly contains port definitions
+ *
+ * created: 2022/11/04 - lfalkau <lfalkau@student.42.fr>
+ * updated: 2022/11/04 - lfalkau <lfalkau@student.42.fr>
+ */
+
+#ifndef PS_2_H
+#define PS_2_H
+
+/* Ports definition */
+
+#define PS2_DATA_PORT 0x60
+#define PS2_STATUS_REGISTER_PORT 0x64
+#define PS2_STATUS_COMMAND_PORT 0x64
+
+/* Status register flags */
+
+#define PS2_OUTPUT_BUFFER_FULL 0x1
+#define PS2_INPUT_BUFFER_FULL 0x2
+
+/* Commands codes */
+
+#define CPU_RESET 0xFE
+
+#endif

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -6,13 +6,14 @@
  * Entrypoint of the KFS kernel
  *
  * created: 2022/10/11 - lfalkau <lfalkau@student.42.fr>
- * updated: 2022/10/21 - mrxx0 <chcoutur@student.42.fr>
+ * updated: 2022/10/29 - mrxx0 <chcoutur@student.42.fr>
  */
 
 #include <kernel/gdt.h>
 #include <kernel/idt.h>
 #include <kernel/keyboard.h>
 #include <kernel/pic_8259.h>
+#include <kernel/port.h>
 #include <kernel/print.h>
 #include <kernel/string.h>
 #include <kernel/vga.h>
@@ -52,6 +53,24 @@ static void print_help() {
 	}
 }
 
+/* Reboot kernel through the PS/2 controller
+ * We wait for the keyboard buffer to be empty, then send
+ * a reset signal to the CPU.
+ * The CPU's RESET pin is 0x64.
+ * The command 0xFx means "pulse the chose line down for 6 milliseconds"
+ * with E choosing the reset line.
+ * The bit will be zeroed and the CPU will start executing code according
+ * to its boot sequence.
+ * */
+static void reboot()
+{
+	uint8_t reboot = 0x02;
+	while (reboot & 0x02)
+		reboot = port_read(0x64);
+	port_write(0x64, 0xFE);
+	asm volatile ("hlt");
+}
+
 void kernel_main(void) {
 	char c = 0;
 	struct kbd_event evt;
@@ -82,7 +101,7 @@ void kernel_main(void) {
 						asm volatile ("int $0x0");
 						break;
 					case KEY_F5:
-						VGA_writestring("Oops, not implemented yet...\n");
+						reboot();
 						break;
 					case KEY_F6:
 						VGA_setcolor(VGA_COLOR_BLACK, VGA_COLOR_BLACK);

--- a/kernel/keyboard/keyboard.c
+++ b/kernel/keyboard/keyboard.c
@@ -6,11 +6,12 @@
  * Keyboard driver
  *
  * created: 2022/10/15 - lfalkau <lfalkau@student.42.fr>
- * updated: 2022/10/19 - lfalkau <lfalkau@student.42.fr>
+ * updated: 2022/11/04 - lfalkau <lfalkau@student.42.fr>
  */
 
 #include <kernel/keyboard.h>
 #include <kernel/port.h>
+#include <kernel/ps2.h>
 #include <kernel/vga.h>
 #include <stdint.h>
 
@@ -57,7 +58,7 @@ void KBD_initialize() {
  * Returns 1 if some keyboard data is available, 0 otherwise
  */
 int KBD_poll() {
-	uint8_t status = port_read(PS2_STATUS_REGISTER);
+	uint8_t status = port_read(PS2_STATUS_REGISTER_PORT);
 
 	return status & 1;
 }
@@ -116,7 +117,7 @@ static void set_modifiers(struct kbd_event *evt) {
  *
  */
 int KBD_getevent(struct kbd_event *evt) {
-	uint8_t sc = port_read(PS2_DATA);
+	uint8_t sc = port_read(PS2_DATA_PORT);
 
 	if (sc == 0xE0) {
 		if (kbd_st.ext)
@@ -187,6 +188,6 @@ void KBD_setkeymap(struct kbd_keymap_entry (*kmfn)(enum kbd_keycode)) {
  *
  */
 void KBD_flush() {
-	uint8_t status = port_read(PS2_STATUS_REGISTER);
-	port_write(PS2_STATUS_REGISTER, status & (0xff << 2));
+	uint8_t status = port_read(PS2_STATUS_REGISTER_PORT);
+	port_write(PS2_STATUS_COMMAND_PORT, status & (0xff << 2));
 }


### PR DESCRIPTION
We can now reboot the system with the F5 key in the menu.
Details on how this works are in the comment above the reboot function in kernel/kernel.c

reboot function is a static one at the moment, we could use it as a global one when we will have a working shell.