### PR TITLE
Move port definitions to a dedicated PS2 .h file

### DIFF
--- a/include/kernel/port.h
+++ b/include/kernel/port.h
@@ -17,9 +17,4 @@
 uint8_t		port_read(uint16_t port);
 void		port_write(uint16_t port, uint8_t val);
 
-/* Ports definition */
-
-#define PS2_DATA 0x60
-#define PS2_STATUS_REGISTER 0x64
-
 #endif

--- a/include/kernel/ps2.h
+++ b/include/kernel/ps2.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: CGL-KFS
+// SPDX-License-Identifier: BSD-3-Clause
+
+/* PS/2 controller header file
+ *
+ * Mainly contains port definitions
+ *
+ * created: 2022/11/04 - lfalkau <lfalkau@student.42.fr>
+ * updated: 2022/11/04 - lfalkau <lfalkau@student.42.fr>
+ */
+
+#ifndef PS_2_H
+#define PS_2_H
+
+/* Ports definition */
+
+#define PS2_DATA_PORT 0x60
+#define PS2_STATUS_REGISTER_PORT 0x64
+#define PS2_STATUS_COMMAND_PORT 0x64
+
+/* Status register flags */
+
+#define PS2_OUTPUT_BUFFER_FULL 0x1
+#define PS2_INPUT_BUFFER_FULL 0x2
+
+/* Commands codes */
+
+#define CPU_RESET 0xFE
+
+#endif

--- a/kernel/keyboard/keyboard.c
+++ b/kernel/keyboard/keyboard.c
@@ -6,11 +6,12 @@
  * Keyboard driver
  *
  * created: 2022/10/15 - lfalkau <lfalkau@student.42.fr>
- * updated: 2022/10/19 - lfalkau <lfalkau@student.42.fr>
+ * updated: 2022/11/04 - lfalkau <lfalkau@student.42.fr>
  */
 
 #include <kernel/keyboard.h>
 #include <kernel/port.h>
+#include <kernel/ps2.h>
 #include <kernel/vga.h>
 #include <stdint.h>
 
@@ -57,7 +58,7 @@ void KBD_initialize() {
  * Returns 1 if some keyboard data is available, 0 otherwise
  */
 int KBD_poll() {
-	uint8_t status = port_read(PS2_STATUS_REGISTER);
+	uint8_t status = port_read(PS2_STATUS_REGISTER_PORT);
 
 	return status & 1;
 }
@@ -116,7 +117,7 @@ static void set_modifiers(struct kbd_event *evt) {
  *
  */
 int KBD_getevent(struct kbd_event *evt) {
-	uint8_t sc = port_read(PS2_DATA);
+	uint8_t sc = port_read(PS2_DATA_PORT);
 
 	if (sc == 0xE0) {
 		if (kbd_st.ext)
@@ -187,6 +188,6 @@ void KBD_setkeymap(struct kbd_keymap_entry (*kmfn)(enum kbd_keycode)) {
  *
  */
 void KBD_flush() {
-	uint8_t status = port_read(PS2_STATUS_REGISTER);
-	port_write(PS2_STATUS_REGISTER, status & (0xff << 2));
+	uint8_t status = port_read(PS2_STATUS_REGISTER_PORT);
+	port_write(PS2_STATUS_COMMAND_PORT, status & (0xff << 2));
 }


### PR DESCRIPTION
Also defines more PS2 flags / commands, to make it's usage more clear and updates the reboot function to use them.

Signed-off-by: lfalkau <lfalkau@student.42.fr>