### PR TITLE
Rework of the PR #28 (hexdump/print_stack)

### DIFF
--- a/include/kernel/gdt.h
+++ b/include/kernel/gdt.h
@@ -6,13 +6,12 @@
  * Global descriptor table header file
  *
  * created: 2022/10/18 - mrxx0 <chcoutur@student.42.fr>
- * updated: 2022/10/26 - mrxx0 <chcoutur@student.42.fr>
+ * updated: 2022/11/18 - mrxx0 <chcoutur@student.42.fr>
  */
 
 #ifndef GDT_H
 #define GDT_H
 
-#define GDT_BASE 0x800
 /* Initialize the gdt and load it. */
 void gdt_init();
 

--- a/include/kernel/gdt.h
+++ b/include/kernel/gdt.h
@@ -6,15 +6,17 @@
  * Global descriptor table header file
  *
  * created: 2022/10/18 - mrxx0 <chcoutur@student.42.fr>
- * updated: 2022/10/19 - lfalkau <lfalkau@student.42.fr>
+ * updated: 2022/10/26 - mrxx0 <chcoutur@student.42.fr>
  */
 
 #ifndef GDT_H
 #define GDT_H
 
 #define GDT_BASE 0x800
-
 /* Initialize the gdt and load it. */
 void gdt_init();
+
+/* Print the GDT info. */
+void gdt_print();
 
 #endif

--- a/include/kernel/memory.h
+++ b/include/kernel/memory.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: CGL-KFS
+// SPDX-License-Identifier: BSD-3-Clause
+
+/* memory.h
+ *
+ * Header file for the kernel memory helpers
+ *
+ * created: 2022/11/19 - lfalkau <lfalkau@student.42.fr>
+ * updated: 2022/11/19 - lfalkau <lfalkau@student.42.fr>
+ */
+
+#ifndef MEMORY_H
+#define MEMORY_H
+
+#include <stdint.h>
+
+void hexdump(uint32_t *base, uint32_t limit);
+
+#endif

--- a/include/kernel/memory.h
+++ b/include/kernel/memory.h
@@ -15,5 +15,6 @@
 #include <stdint.h>
 
 void hexdump(uint32_t *base, uint32_t limit);
+void print_stack();
 
 #endif

--- a/kernel/boot.s
+++ b/kernel/boot.s
@@ -27,7 +27,7 @@
 .section .bss
 .align 16
 stack_bottom:
-.skip 16384 # 16 KiB
+	.skip 16384
 stack_top:
 	.section .text
 	.global _start

--- a/kernel/gdt.c
+++ b/kernel/gdt.c
@@ -6,11 +6,14 @@
  * Fill the gdt entries and load it.
  *
  * created: 2022/10/18 - mrxx0 <chcoutur@student.42.fr>
- * updated: 2022/10/20 - mrxx0 <chcoutur@student.42.fr>
+ * updated: 2022/11/21 - lfalkau <lfalkau@student.42.fr>
  */
 
 #include <stdint.h>
 #include <kernel/gdt.h>
+#include <kernel/keyboard.h>
+#include <kernel/vga.h>
+#include <kernel/print.h>
 
 #include "gdt_internal.h"
 
@@ -41,15 +44,38 @@ static void gdt_set_gate(int num, uint32_t base, uint32_t limit, uint8_t access,
  */
 void gdt_init()
 {
-	gdtp.limit = (sizeof(t_gdt_entry) * 7) - 1;
+	gdtp.limit = (sizeof(t_gdt_entry) * 6);
 	gdtp.base = (uint32_t)gdt;
-	gdt_set_gate(0,	0,	0,	0,	0);	// NULL descriptor
+	gdt_set_gate(0,	0,	0x0000,	0,	0);	// NULL descriptor
 	gdt_set_gate(1,	0,	0xFFFF,	0x9A,	0xCF);	// Kernel Mode Code Segment
 	gdt_set_gate(2,	0,	0xFFFF,	0x92,	0xCF);	// Kernel Mode Data Segment
 	gdt_set_gate(3,	0,	0xFFFF,	0x96,	0xCF);	// Kernel Mode Stack Segment
 	gdt_set_gate(4,	0,	0xFFFF,	0xFA,	0xCF);	// User Mode Code Segment
 	gdt_set_gate(5,	0,	0xFFFF,	0xF2,	0xCF);	// User Mode Data Segment
-	gdt_set_gate(6,	0,	0xFFFF,	0x96,	0xCF);	// User Mode Stack Segment
+	gdt_set_gate(6,	0,	0xFFFF,	0xF6,	0xCF);	// User Mode Stack Segment
 	gdt_flush(&gdtp);
 }
 
+/* Print all the info from the gdt basic info and all of the entries
+ *
+ */
+void gdt_print() {
+	VGA_setforegroundcolor(VGA_COLOR_LIGHT_BROWN);
+	kprintf("-- GDT --\n");
+	VGA_setforegroundcolor(VGA_COLOR_WHITE);
+	kprintf("Base: %8p\n", gdt);
+	kprintf("Limit: %p\n", gdtp.limit);
+	kprintf("Entries:\n\n");
+	VGA_setforegroundcolor(VGA_COLOR_LIGHT_BROWN);
+	kprintf("BASE LOW    BASE MID    BASE HIGH   LIMIT LOW   GRAN        ACC\n");
+	VGA_setforegroundcolor(VGA_COLOR_WHITE);
+	for (uint8_t i = 0; i < GDT_SIZE; i++) {
+		kprintf("%4p      ", gdt[i].base_low);
+		kprintf("%4p      ", gdt[i].base_middle);
+		kprintf("%4p      ", gdt[i].base_high);
+		kprintf("%4p      ", gdt[i].limit_low);
+		kprintf("%4p      ", gdt[i].granularity);
+		kprintf("%4p      ", gdt[i].access);
+		kprintf("\n");
+	}
+}

--- a/kernel/gdt.c
+++ b/kernel/gdt.c
@@ -17,10 +17,82 @@
 
 #include "gdt_internal.h"
 
+/* GDT entries information
+ */
+#define GDT_BASE_ADDRESS 0x800
+#define GDT_SIZE 0x6
+#define GDT_KERNEL_LIMIT 0xFFFF
+#define GDT_USER_LIMIT 0xFFFF
+#define GDT_GRAN_BASE 0xCF
+#define GDT_ENTRY_NULL 0x0
+#define GDT_KERNEL_CODE 0x1
+#define GDT_KERNEL_DATA 0x2
+#define GDT_KERNEL_STACK 0x3
+#define GDT_USER_CODE 0x4
+#define GDT_USER_DATA 0x5
+#define GDT_USER_STACK 0x6
+#define GDT_BASE_SEGMENT 0x0
+
+/* GDT entries operations to retrieve segment value and segment access
+ */
+#define SEG_DESCTYPE(x) ((x) << 0x04)
+#define SEG_PRES(x) ((x) << 0x07)
+#define SEG_SAVL(x) ((x) << 0x0C)
+#define SEG_LONG(x) ((x) << 0x0D)
+#define SEG_SIZE(x) ((x) << 0x0E)
+#define SEG_GRAN(x) ((x) << 0x0F)
+#define SEG_PRIV(x) (((x)&0x03) << 0x05)
+#define SEG_DATA_RD 0x00        // Read-Only
+#define SEG_DATA_RDA 0x01       // Read-Only, accessed
+#define SEG_DATA_RDWR 0x02      // Read/Write
+#define SEG_DATA_RDWRA 0x03     // Read/Write, accessed
+#define SEG_DATA_RDEXPD 0x04    // Read-Only, expand-down
+#define SEG_DATA_RDEXPDA 0x05   // Read-Only, expand-down, accessed
+#define SEG_DATA_RDWREXPD 0x06  // Read/Write, expand-down
+#define SEG_DATA_RDWREXPDA 0x07 // Read/Write, expand-down, accessed
+#define SEG_CODE_EX 0x08        // Execute-Only
+#define SEG_CODE_EXA 0x09       // Execute-Only, accessed
+#define SEG_CODE_EXRD 0x0A      // Execute/Read
+#define SEG_CODE_EXRDA 0x0B     // Execute/Read, accessed
+#define SEG_CODE_EXC 0x0C       // Execute-Only, conforming
+#define SEG_CODE_EXCA 0x0D      // Execute-Only, conforming, accessed
+#define SEG_CODE_EXRDC 0x0E     // Execute/Read, conforming
+#define SEG_CODE_EXRDCA 0x0F    // Execute/Read, conforming, accessed
+
+/* GDT_KERNEL_CODE_ACCESS - 0x9A */
+#define GDT_KERNEL_CODE_ACCESS SEG_DESCTYPE(1) | SEG_PRES(1) | SEG_SAVL(0) | \
+                         SEG_LONG(0) | SEG_SIZE(1) | SEG_GRAN(1) | \
+                         SEG_PRIV(0) | SEG_CODE_EXRD
+
+/* GDT_KERNEL_DATA_ACCESS - 0x92 */
+#define GDT_KERNEL_DATA_ACCESS SEG_DESCTYPE(1) | SEG_PRES(1) | SEG_SAVL(0) | \
+                         SEG_LONG(0) | SEG_SIZE(1) | SEG_GRAN(1) | \
+                         SEG_PRIV(0) | SEG_DATA_RDWR
+
+/* GDT_KERNEL_STACK_ACCESS - 0x96 */
+#define GDT_KERNEL_STACK_ACCESS SEG_DESCTYPE(1) | SEG_PRES(1) | SEG_SAVL(0) | \
+                          SEG_LONG(0) | SEG_SIZE(1) | SEG_GRAN(1) | \
+                          SEG_PRIV(0) | SEG_DATA_RDWREXPD
+
+/* GDT_USER_CODE_ACCESS - 0xFA */
+#define GDT_USER_CODE_ACCESS SEG_DESCTYPE(1) | SEG_PRES(1) | SEG_SAVL(0) | \
+                         SEG_LONG(0) | SEG_SIZE(1) | SEG_GRAN(1) | \
+                         SEG_PRIV(3) | SEG_CODE_EXRD
+
+/* GDT_USER_DATA_ACCESS - 0xF2 */
+#define GDT_USER_DATA_ACCESS SEG_DESCTYPE(1) | SEG_PRES(1) | SEG_SAVL(0) | \
+                         SEG_LONG(0) | SEG_SIZE(1) | SEG_GRAN(1) | \
+                         SEG_PRIV(3) | SEG_DATA_RDWR
+
+/* GDT_USER_STACK_ACCESS - 0xF6 */
+#define GDT_USER_STACK_ACCESS SEG_DESCTYPE(1) | SEG_PRES(1) | SEG_SAVL(0) | \
+                          SEG_LONG(0) | SEG_SIZE(1) | SEG_GRAN(1) | \
+                          SEG_PRIV(3) | SEG_DATA_RDWREXPD
+
 extern void gdt_flush();
 
 /* Pointer to the gdt. */
-static t_gdt_entry *gdt = (t_gdt_entry *)GDT_BASE;
+static t_gdt_entry *gdt = (t_gdt_entry *)GDT_BASE_ADDRESS;
 
 /* Store a pointer to the gdt and its size. */
 static t_gdt_ptr gdtp;
@@ -44,15 +116,15 @@ static void gdt_set_gate(int num, uint32_t base, uint32_t limit, uint8_t access,
  */
 void gdt_init()
 {
-	gdtp.limit = (sizeof(t_gdt_entry) * 6);
+	gdtp.limit = (sizeof(t_gdt_entry) * GDT_SIZE);
 	gdtp.base = (uint32_t)gdt;
-	gdt_set_gate(0,	0,	0x0000,	0,	0);	// NULL descriptor
-	gdt_set_gate(1,	0,	0xFFFF,	0x9A,	0xCF);	// Kernel Mode Code Segment
-	gdt_set_gate(2,	0,	0xFFFF,	0x92,	0xCF);	// Kernel Mode Data Segment
-	gdt_set_gate(3,	0,	0xFFFF,	0x96,	0xCF);	// Kernel Mode Stack Segment
-	gdt_set_gate(4,	0,	0xFFFF,	0xFA,	0xCF);	// User Mode Code Segment
-	gdt_set_gate(5,	0,	0xFFFF,	0xF2,	0xCF);	// User Mode Data Segment
-	gdt_set_gate(6,	0,	0xFFFF,	0xF6,	0xCF);	// User Mode Stack Segment
+	gdt_set_gate(GDT_ENTRY_NULL,	GDT_ENTRY_NULL,		GDT_ENTRY_NULL,		GDT_ENTRY_NULL,							GDT_ENTRY_NULL);	// NULL descriptor
+	gdt_set_gate(GDT_KERNEL_CODE,	GDT_BASE_SEGMENT,	GDT_KERNEL_LIMIT,	(uint8_t)(GDT_KERNEL_CODE_ACCESS),		GDT_GRAN_BASE);		// Kernel Mode Code Segment
+	gdt_set_gate(GDT_KERNEL_DATA,	GDT_BASE_SEGMENT,	GDT_KERNEL_LIMIT,	(uint8_t)(GDT_KERNEL_DATA_ACCESS),		GDT_GRAN_BASE);		// Kernel Mode Data Segment
+	gdt_set_gate(GDT_KERNEL_STACK,	GDT_BASE_SEGMENT,	GDT_KERNEL_LIMIT,	(uint8_t)(GDT_KERNEL_STACK_ACCESS),		GDT_GRAN_BASE);		// Kernel Mode Stack Segment
+	gdt_set_gate(GDT_USER_CODE,		GDT_BASE_SEGMENT,	GDT_USER_LIMIT,		(uint8_t)(GDT_USER_CODE_ACCESS),			GDT_GRAN_BASE);		// User Mode Code Segment
+	gdt_set_gate(GDT_USER_DATA,		GDT_BASE_SEGMENT,	GDT_USER_LIMIT,		(uint8_t)(GDT_USER_DATA_ACCESS),			GDT_GRAN_BASE);		// User Mode Data Segment
+	gdt_set_gate(GDT_USER_STACK,	GDT_BASE_SEGMENT,	GDT_USER_LIMIT,		(uint8_t)(GDT_USER_STACK_ACCESS),			GDT_GRAN_BASE);		// User Mode Stack Segment
 	gdt_flush(&gdtp);
 }
 

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -109,9 +109,7 @@ void kernel_main(void) {
 						KBD_setkeymap(FR_getkeymapentry);
 						break;
 					case KEY_F10:
-						uint32_t ebp;
-						asm inline volatile ("mov %%ebp, %0" :: "r"(ebp));
-						hexdump(&ebp + 1, 4096);
+						print_stack();
 						break;
 					case KEY_F11:
 						gdt_print();

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -16,7 +16,7 @@
 #include <kernel/port.h>
 #include <kernel/ps2.h>
 #include <kernel/print.h>
-#include <kernel/string.h>
+#include <kernel/memory.h>
 #include <kernel/vga.h>
 
 extern struct vga vga;
@@ -41,8 +41,8 @@ static void print_help() {
 		[7] = " Go to normal mode",
 		[8] = " Switch to qwerty",
 		[9] = " Switch to azerty",
-		[10] = "N/A",
-		[11] = "N/A",
+		[10] = "Print the stack",
+		[11] = "Print the GDT",
 		[12] = "Reset terminal",
 	};
 
@@ -68,7 +68,6 @@ static void reboot()
 void kernel_main(void) {
 	char c = 0;
 	struct kbd_event evt;
-
 	init_descriptor_tables();
 
 	VGA_initialize();
@@ -108,6 +107,14 @@ void kernel_main(void) {
 						break;
 					case KEY_F9:
 						KBD_setkeymap(FR_getkeymapentry);
+						break;
+					case KEY_F10:
+						uint32_t ebp;
+						asm inline volatile ("mov %%ebp, %0" :: "r"(ebp));
+						hexdump(&ebp + 1, 4096);
+						break;
+					case KEY_F11:
+						gdt_print();
 						break;
 					case KEY_F12:
 						vga.color = VGA_DFL_COLOR;

--- a/kernel/memory/Makefile
+++ b/kernel/memory/Makefile
@@ -21,6 +21,7 @@ builddir?= build
 
 src-y:= \
 	hexdump.c \
+	print_stack.c \
 
 objs:= $(addprefix ${builddir}/, ${src-y})
 objs:= ${objs:.c=.o}

--- a/kernel/memory/Makefile
+++ b/kernel/memory/Makefile
@@ -11,29 +11,16 @@ ASFLAGS+=
 AR:= ${cross-target}-ar
 ARFLAGS:= rc
 CC:= ${cross-target}-gcc
-CFLAGS+= -ffreestanding -nostdlib -nodefaultlibs -fno-builtin -mgeneral-regs-only -MMD $(addprefix -I, ${.INCLUDE_DIRS})
+CFLAGS+= -ffreestanding -nostdlib -nodefaultlibs -fno-builtin -MMD $(addprefix -I, ${.INCLUDE_DIRS})
 LD:= ${cross-target}-ld
 LDFLAGS+=
 
 # BUILD VAR
-subdir:= \
-		 keyboard \
-		 memory \
 
 builddir?= build
 
 src-y:= \
-	kernel.c \
-	boot.s \
-	port.c \
-	vga.c \
-	print.c \
-	gdt.c \
-	gdt_flush.s \
-	idt.c \
-	isr.c \
-	spinlock.c \
-	pic_8259.c \
+	hexdump.c \
 
 objs:= $(addprefix ${builddir}/, ${src-y})
 objs:= ${objs:.c=.o}

--- a/kernel/memory/hexdump.c
+++ b/kernel/memory/hexdump.c
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: CGL-KFS
+// SPDX-License-Identifier: BSD-3-Clause
+
+/* hexdump.c
+ *
+ * Exports a hexdump function to print memory
+ *
+ * created: 2022/11/19 - lfalkau <lfalkau@student.42.fr>
+ * updated: 2022/11/19 - lfalkau <lfalkau@student.42.fr>
+ */
+
+#include <kernel/vga.h>
+#include <kernel/print.h>
+#include <kernel/keyboard.h>
+
+static void wait_for_char_input(int c) {
+	struct kbd_event evt;
+
+	while (1) {
+		while (!KBD_poll());
+		KBD_getevent(&evt);
+		if (evt.type == KEY_PRESSED) {
+			if (c == 0 || KBD_getchar(&evt) == c)
+				break;
+		}
+	}
+}
+
+static int hexdump_diaplay_char(int c) {
+	if (c == 0) {
+		VGA_setforegroundcolor(VGA_COLOR_WHITE);
+		return '.';
+	} else if (c < 32 || c > 127) {
+		VGA_setforegroundcolor(VGA_COLOR_LIGHT_BLUE);
+		return '.';
+	} else {
+		VGA_setforegroundcolor(VGA_COLOR_LIGHT_GREEN);
+		return c;
+	}
+}
+
+/* Hexdump to print from address to limit
+ *
+ * @base is the address to start the print from
+ * @limit is number of bytes we want to print
+ *
+ */
+void hexdump(uint8_t *base, uint32_t limit) {
+	struct kbd_event evt;
+	uint32_t l = 0, i = 0;
+
+	while (i < limit) {
+		kprintf("%8p:  ", base + i);
+		for (uint32_t j = i; j < limit && j < i + 16; j++) {
+			VGA_setforegroundcolor(base[j] ? VGA_COLOR_LIGHT_GREEN : VGA_COLOR_WHITE);
+			kprintf("%2x ", base[j]);
+		}
+		kprintf(" ");
+		for (uint32_t j = i; j < limit && j < i + 16; j++) {
+			kprintf("%c", hexdump_diaplay_char(base[j]));
+		}
+		l += 1;
+		if (l == VGA_HEIGHT) {
+			wait_for_char_input(' ');
+			VGA_clear();
+			l = 0;
+		} else {
+			kprintf("\n");
+		}
+		VGA_setforegroundcolor(VGA_COLOR_WHITE);
+		i += 16;
+	}
+}

--- a/kernel/memory/print_stack.c
+++ b/kernel/memory/print_stack.c
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: CGL-KFS
+// SPDX-License-Identifier: BSD-3-Clause
+
+/* kernel/memory/print_stack.c
+ *
+ * Helper function to print the kernel stack
+ *
+ * created: 2022/11/19 - lfalkau <lfalkau@student.42.fr>
+ * updated: 2022/11/19 - lfalkau <lfalkau@student.42.fr>
+ */
+
+#include <kernel/memory.h>
+
+extern uint32_t *stack_bottom;
+
+void print_stack() {
+	uint32_t stack_size = 16384;
+	hexdump(stack_bottom, stack_size);	
+}

--- a/lib/string/mem.c
+++ b/lib/string/mem.c
@@ -6,10 +6,11 @@
  * memory related functions of the string library
  *
  * created: 2022/10/12 - lfalkau <lfalkau@student.42.fr>
- * updated: 2022/10/19 - lfalkau <lfalkau@student.42.fr>
+ * updated: 2022/11/18 - lfalkau <lfalkau@student.42.fr>
  */
 
 #include <stddef.h>
+#include <stdint.h>
 
 void *memchr(const void *s, int c, size_t n) {
 	unsigned char *sc = (unsigned char *)s;


### PR DESCRIPTION
This pull request is a rework of #28.

Content:
- A simple padding modifier implementation for the `kprintf` function, allowing to align integers in order to make things prettier.
- A complete rewrite of the `hexdump` function. I think this implementation is more straightforward, due to the padding feature and some refactorisation. (the space key is now used to print the next page of memory).
- A `print_stack` function implementation, that prints the whole kernel stack.
- Some rework on the commits. Each of the previous feature is addressed in a single simple commit.

Others features are left unchanged from the PR #28 