### PR TITLE
Fix stack addresses + minor correction

### DIFF
--- a/include/kernel/memory.h
+++ b/include/kernel/memory.h
@@ -14,7 +14,7 @@
 
 #include <stdint.h>
 
-void hexdump(uint32_t *base, uint32_t limit);
+void hexdump(void *base, uint32_t limit);
 void print_stack();
 
 #endif

--- a/kernel/memory/hexdump.c
+++ b/kernel/memory/hexdump.c
@@ -47,21 +47,22 @@ static int hexdump_diaplay_char(int c) {
  * @limit is number of bytes we want to print
  *
  */
-void hexdump(uint8_t *base, uint32_t limit) {
+void hexdump(void *base, uint32_t limit) {
 	struct kbd_event evt;
 	uint32_t l = 0, i = 0;
 	uint8_t oldcolor = vga.color;
+	uint8_t *p = (uint8_t *)base;
 
 	VGA_setforegroundcolor(VGA_COLOR_WHITE);
 	while (i < limit) {
-		kprintf("%8p:  ", base + i);
+		kprintf("%8p:  ", p + i);
 		for (uint32_t j = i; j < limit && j < i + 16; j++) {
-			VGA_setforegroundcolor(base[j] ? VGA_COLOR_LIGHT_GREEN : VGA_COLOR_WHITE);
-			kprintf("%2x ", base[j]);
+			VGA_setforegroundcolor(p[j] ? VGA_COLOR_LIGHT_GREEN : VGA_COLOR_WHITE);
+			kprintf("%2x ", p[j]);
 		}
 		kprintf(" ");
 		for (uint32_t j = i; j < limit && j < i + 16; j++) {
-			kprintf("%c", hexdump_diaplay_char(base[j]));
+			kprintf("%c", hexdump_diaplay_char(p[j]));
 		}
 		l += 1;
 		if (l == VGA_HEIGHT) {
@@ -76,3 +77,4 @@ void hexdump(uint8_t *base, uint32_t limit) {
 	}
 	vga.color = oldcolor;
 }
+

--- a/kernel/memory/print_stack.c
+++ b/kernel/memory/print_stack.c
@@ -6,14 +6,14 @@
  * Helper function to print the kernel stack
  *
  * created: 2022/11/19 - lfalkau <lfalkau@student.42.fr>
- * updated: 2022/11/19 - lfalkau <lfalkau@student.42.fr>
+ * updated: 2022/11/21 - mrxx0 <chcoutur@student.42.fr>
  */
 
 #include <kernel/memory.h>
 
-extern uint32_t *stack_bottom;
+extern void *stack_bottom;
+extern void *stack_top;
 
 void print_stack() {
-	uint32_t stack_size = 16384;
-	hexdump(stack_bottom, stack_size);	
+	hexdump(&stack_bottom, (void *)&stack_top - (void *)&stack_bottom);
 }

--- a/kernel/shell.c
+++ b/kernel/shell.c
@@ -86,7 +86,7 @@ static void handle_command()
  */
 static void fill_buffer(char c, uint8_t i)
 {
-	if (i < 20)
+	if (i < BUFSIZE - 1)
 		buffer[i] = c;
 }
 


### PR DESCRIPTION
- Fix stack top/bottom addresses in print_stack function.
- Make use of the BUFSIZE define as the read limit.
- Take a void* as hexdump base parameter.