### PR TITLE
Create driver for PIT and some time functions

### DIFF
--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -18,6 +18,7 @@ LDFLAGS+=
 # BUILD VAR
 subdir:= \
 		 rtc \
+		 pit \
 
 builddir?= build
 

--- a/drivers/pit/Makefile
+++ b/drivers/pit/Makefile
@@ -17,26 +17,11 @@ LDFLAGS+=
 
 # BUILD VAR
 subdir:= \
-		 keyboard \
-		 memory \
-		 nsh \
 
 builddir?= build
 
 src-y:= \
-	kernel.c \
-	boot.s \
-	boot_init.c \
-	port.c \
-	print.c \
-	gdt.c \
-	gdt_flush.s \
-	idt.c \
-	isr.c \
-	spinlock.c \
-	pic_8259.c \
-	screenbuf.c \
-	time.c \
+	pit.c
 
 objs:= $(addprefix ${builddir}/, ${src-y})
 objs:= ${objs:.c=.o}

--- a/drivers/pit/pit.c
+++ b/drivers/pit/pit.c
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: CGL-KFS
+// SPDX-License-Identifier: BSD-3-Clause
+
+/* drivers/pit/pit.c
+ *
+ *
+ *
+ * created: 2022/12/14 - xlmod <glafond-@student.42.fr>
+ * updated: 2022/12/14 - xlmod <glafond-@student.42.fr>
+ */
+
+#include <stdint.h>
+#include <kernel/pit.h>
+#include <kernel/port.h>
+
+#define PIT_INTERNAL_FREQ 1193180
+
+#define PIT_DATA_PORT 0x40
+#define PIT_CMD_PORT 0x43
+
+uint32_t pit_freq = 20; // Hz
+uint32_t pit_counter = 0;
+
+void pit_init() {
+	pit_set_freq(pit_freq);
+}
+
+void pit_set_freq(uint32_t freq) {
+	uint16_t div = PIT_INTERNAL_FREQ / freq;
+	pit_freq = PIT_INTERNAL_FREQ / div;
+	port_write_u8(PIT_CMD_PORT, 0x36);
+	port_write_u8(PIT_DATA_PORT, div & 0xff);
+	port_write_u8(PIT_DATA_PORT, div >> 8);
+}

--- a/drivers/pit/pit.c
+++ b/drivers/pit/pit.c
@@ -3,10 +3,10 @@
 
 /* drivers/pit/pit.c
  *
- *
+ * Driver for pit (Programmable Interval Timer)
  *
  * created: 2022/12/14 - xlmod <glafond-@student.42.fr>
- * updated: 2022/12/14 - xlmod <glafond-@student.42.fr>
+ * updated: 2023/01/18 - glafond- <glafond-@student.42.fr>
  */
 
 #include <stdint.h>
@@ -18,17 +18,26 @@
 #define PIT_DATA_PORT 0x40
 #define PIT_CMD_PORT 0x43
 
-uint32_t pit_freq = 20; // Hz
-uint32_t pit_counter = 0;
+#define PIT_TIMER_MODE_SQUARE 3
+#define PIT_TIMER_RW_LSBMSB 3
 
-void pit_init() {
-	pit_set_freq(pit_freq);
+#define PIT_SETTIMER_CMD(mode, rw) ((mode << 1) | (rw << 4))
+
+volatile uint32_t pit_freq = 1193; // Hz
+volatile uint32_t pit_freq_mod = 0;
+
+volatile uint32_t pit_counter_div = 0;
+volatile uint32_t pit_counter_mod = 0;
+
+static inline void pit_set_freq(uint32_t freq) {
+	uint16_t divisor = PIT_INTERNAL_FREQ / freq;
+	pit_freq_mod = PIT_INTERNAL_FREQ % freq;
+	pit_freq = freq;
+	port_write_u8(PIT_CMD_PORT, PIT_SETTIMER_CMD(PIT_TIMER_MODE_SQUARE, PIT_TIMER_RW_LSBMSB));
+	port_write_u8(PIT_DATA_PORT, divisor & 0xff);
+	port_write_u8(PIT_DATA_PORT, divisor >> 8);
 }
 
-void pit_set_freq(uint32_t freq) {
-	uint16_t div = PIT_INTERNAL_FREQ / freq;
-	pit_freq = PIT_INTERNAL_FREQ / div;
-	port_write_u8(PIT_CMD_PORT, 0x36);
-	port_write_u8(PIT_DATA_PORT, div & 0xff);
-	port_write_u8(PIT_DATA_PORT, div >> 8);
+void pit_init() {
+	pit_set_freq(1193);
 }

--- a/include/kernel/pit.h
+++ b/include/kernel/pit.h
@@ -3,10 +3,10 @@
 
 /* include/kernel/pit.h
  *
- *
+ * Driver for pit (Programmable Interval Timer)
  *
  * created: 2022/12/14 - xlmod <glafond-@student.42.fr>
- * updated: 2022/12/15 - xlmod <glafond-@student.42.fr>
+ * updated: 2022/12/15 - glafond- <glafond-@student.42.fr>
  */
 
 #ifndef PIT_H
@@ -14,12 +14,15 @@
 
 #include <stdint.h>
 
-#define PIT_TIMEMS ((pit_counter * 1000) / pit_freq)
+#define PIT_TIMEMS (pit_counter_div * 1000 + (pit_counter_mod * 1000) / pit_freq)
+#define PIT_REALTIMEMS (PIT_TIMEMS + ((PIT_TIMEMS/1000000) * pit_freq_mod))
 
-extern uint32_t pit_freq;
-extern uint32_t pit_counter;
+extern volatile uint32_t pit_freq;
+extern volatile uint32_t pit_freq_mod;
+
+extern volatile uint32_t pit_counter_div;
+extern volatile uint32_t pit_counter_mod;
 
 void pit_init();
-void pit_set_freq(uint32_t freq);
 
 #endif

--- a/include/kernel/pit.h
+++ b/include/kernel/pit.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: CGL-KFS
+// SPDX-License-Identifier: BSD-3-Clause
+
+/* include/kernel/pit.h
+ *
+ *
+ *
+ * created: 2022/12/14 - xlmod <glafond-@student.42.fr>
+ * updated: 2022/12/15 - xlmod <glafond-@student.42.fr>
+ */
+
+#ifndef PIT_H
+#define PIT_H
+
+#include <stdint.h>
+
+#define PIT_TIMEMS ((pit_counter * 1000) / pit_freq)
+
+extern uint32_t pit_freq;
+extern uint32_t pit_counter;
+
+void pit_init();
+void pit_set_freq(uint32_t freq);
+
+#endif

--- a/include/kernel/time.h
+++ b/include/kernel/time.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: CGL-KFS
+// SPDX-License-Identifier: BSD-3-Clause
+
+/* include/kernel/time.h
+ *
+ * Insert file description here
+ *
+ * created: 2022/12/14 - xlmod <glafond-@student.42.fr>
+ * updated: 2022/12/15 - xlmod <glafond-@student.42.fr>
+ */
+
+#ifndef TIME_T
+#define TIME_T
+
+#include <stdint.h>
+
+/*
+ * Sleep at least ms millisecond
+ */
+void sleep(uint32_t ms);
+
+/*
+ * Return the time since the kernel start in millisecond
+ */
+uint32_t gettime();
+
+#endif

--- a/include/kernel/time.h
+++ b/include/kernel/time.h
@@ -3,16 +3,18 @@
 
 /* include/kernel/time.h
  *
- * Insert file description here
+ * Time relative functions
  *
  * created: 2022/12/14 - xlmod <glafond-@student.42.fr>
- * updated: 2022/12/15 - xlmod <glafond-@student.42.fr>
+ * updated: 2022/12/15 - glafond- <glafond-@student.42.fr>
  */
 
 #ifndef TIME_T
 #define TIME_T
 
 #include <stdint.h>
+
+typedef uint32_t time_t;
 
 /*
  * Sleep at least ms millisecond

--- a/kernel/isr.c
+++ b/kernel/isr.c
@@ -7,7 +7,7 @@
  * and interrupts
  *
  * created: 2022/10/18 - xlmod <glafond-@student.42.fr>
- * updated: 2022/12/14 - xlmod <glafond-@student.42.fr>
+ * updated: 2022/12/15 - glafond- <glafond-@student.42.fr>
  */
 
 #include <kernel/print.h>
@@ -87,7 +87,12 @@ __attribute__ ((interrupt)) void timer_handler(t_int_frame *int_frame)
 {
 	LOAD_INTERRUPT_STACK;
 	pic_8259_eoi(IRQ_TM);
-	pit_counter++;
+
+	pit_counter_mod++;
+	pit_counter_mod %= pit_freq;
+	if (!pit_counter_mod)
+		pit_counter_div++;
+
 	RESET_INTERRUPT_STACK;
 }
 

--- a/kernel/isr.c
+++ b/kernel/isr.c
@@ -7,11 +7,12 @@
  * and interrupts
  *
  * created: 2022/10/18 - xlmod <glafond-@student.42.fr>
- * updated: 2022/10/21 - mrxx0 <chcoutur@student.42.fr>
+ * updated: 2022/12/14 - xlmod <glafond-@student.42.fr>
  */
 
 #include <kernel/print.h>
 #include <kernel/pic_8259.h>
+#include <kernel/pit.h>
 
 #include "idt_internal.h"
 
@@ -86,6 +87,7 @@ __attribute__ ((interrupt)) void timer_handler(t_int_frame *int_frame)
 {
 	LOAD_INTERRUPT_STACK;
 	pic_8259_eoi(IRQ_TM);
+	pit_counter++;
 	RESET_INTERRUPT_STACK;
 }
 

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -38,10 +38,9 @@ static void init_descriptor_tables() {
 void kernel_main(unsigned long multiboot_info_addr) {
 	multiboot_info_t *mbi = (multiboot_info_t *)multiboot_info_addr;
 
-	kernel_init();
+	pit_init();
 	init_descriptor_tables();
 	KBD_initialize();
-	pit_init();
 
 	kpm_init((void *)mbi->mmap_addr,
 		mbi->mmap_length / sizeof(struct multiboot_mmap_entry),

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -6,7 +6,7 @@
  * Entrypoint of the KFS kernel
  *
  * created: 2022/10/11 - lfalkau <lfalkau@student.42.fr>
- * updated: 2022/12/15 - mrxx0 <chcoutur@student.42.fr>
+ * updated: 2023/01/18 - glafond- <glafond-@student.42.fr>
  */
 
 #include <kernel/gdt.h>
@@ -17,6 +17,8 @@
 #include <kernel/kpm.h>
 #include <kernel/screenbuf.h>
 #include <kernel/nsh.h>
+#include <kernel/pit.h>
+#include <kernel/time.h>
 
 #define NBSCREENBUF 2
 
@@ -36,8 +38,10 @@ static void init_descriptor_tables() {
 void kernel_main(unsigned long multiboot_info_addr) {
 	multiboot_info_t *mbi = (multiboot_info_t *)multiboot_info_addr;
 
+	kernel_init();
 	init_descriptor_tables();
 	KBD_initialize();
+	pit_init();
 
 	kpm_init((void *)mbi->mmap_addr,
 		mbi->mmap_length / sizeof(struct multiboot_mmap_entry),

--- a/kernel/time.c
+++ b/kernel/time.c
@@ -3,10 +3,10 @@
 
 /* kernel/time.c
  *
- *
+ * Time relative functions
  *
  * created: 2022/12/14 - xlmod <glafond-@student.42.fr>
- * updated: 2022/12/15 - xlmod <glafond-@student.42.fr>
+ * updated: 2022/12/15 - glafond- <glafond-@student.42.fr>
  */
 
 #include <stdint.h>
@@ -14,11 +14,17 @@
 #include <kernel/time.h>
 #include <kernel/pit.h>
 
+/*
+ * Sleep at least ms millisecond
+ */
 void sleep(uint32_t ms) {
-	uint32_t time = PIT_TIMEMS + ms;
-	while (PIT_TIMEMS < time);
+	uint32_t time = PIT_REALTIMEMS + ms;
+	while (PIT_REALTIMEMS < time);
 }
 
+/*
+ * Return the time since the kernel start in millisecond
+ */
 uint32_t gettime() {
-	return PIT_TIMEMS;
+	return PIT_REALTIMEMS;
 }

--- a/kernel/time.c
+++ b/kernel/time.c
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: CGL-KFS
+// SPDX-License-Identifier: BSD-3-Clause
+
+/* kernel/time.c
+ *
+ *
+ *
+ * created: 2022/12/14 - xlmod <glafond-@student.42.fr>
+ * updated: 2022/12/15 - xlmod <glafond-@student.42.fr>
+ */
+
+#include <stdint.h>
+
+#include <kernel/time.h>
+#include <kernel/pit.h>
+
+void sleep(uint32_t ms) {
+	uint32_t time = PIT_TIMEMS + ms;
+	while (PIT_TIMEMS < time);
+}
+
+uint32_t gettime() {
+	return PIT_TIMEMS;
+}


### PR DESCRIPTION
PIT (Programmable Interval Timer) generate interrupt at regular interval.
Create a function to set the frequence of this interval and a init function and add it in kernel_init.

Create time relative functions using pit interface. A sleep function that return after at least the number of millisecond given in arguments and a gettime function that return the number of millisecond since kernel the kernel start (in reality it's since the interrupts are enabled).