### PR TITLE
Fix #48 and upgrade info buddy

### DIFF
--- a/kernel/nsh/builtins/alloc.c
+++ b/kernel/nsh/builtins/alloc.c
@@ -6,7 +6,7 @@
  * Allocate builtin file
  *
  * created: 2022/12/13 - glafond- <glafond-@student.42.fr>
- * updated: 2022/12/16 - lfalkau <lfalkau@student.42.fr>
+ * updated: 2022/12/19 - mrxx0 <chcoutur@student.42.fr>
  */
 
 #include <kernel/kpm.h>
@@ -32,14 +32,16 @@ int alloc_loop(kpm_chunk_t *chunk, size_t size) {
 	uint8_t oldcolor = sb_get_color(sb_current);
 	sb_set_fg(sb_current, SB_COLOR_GREEN);
 	while (size > 0) {
-		if (kpm_alloc(chunk, size) < 0)
+		if (kpm_alloc(chunk, size) < 0) {
+			sb_set_color(sb_current, oldcolor);
 			return -1;
+		}
 		kprintf("chunk: {\n    addr = %p\n    size = %u\n}\n", chunk->addr, chunk->size);
 		if (chunk->size >= size)
 			break ;
 		size -= chunk->size;
 	}
-	sb_set_fg(sb_current, oldcolor);
+	sb_set_color(sb_current, oldcolor);
 	return 0;
 }
 
@@ -58,8 +60,8 @@ int alloc(int argc, char **argv) {
 		return -1;
 	}
 	char *ptr;
-	int size = strtol(argv[1], &ptr, 0);
-	if (*ptr != 0) {
+	int32_t size = strtol(argv[1], &ptr, 0);
+	if (*ptr != 0 || size < 0) {
 		kprintf(BLTNAME ": Size not well formatted.\n");
 		return -1;
 	}

--- a/kernel/nsh/builtins/free.c
+++ b/kernel/nsh/builtins/free.c
@@ -6,7 +6,7 @@
  * Free builtin file
  *
  * created: 2022/12/15 - mrxx0 <chcoutur@student.42.fr>
- * updated: 2022/12/15 - mrxx0 <chcoutur@student.42.fr>
+ * updated: 2022/12/19 - mrxx0 <chcoutur@student.42.fr>
  */
 
 #include <kernel/kpm.h>
@@ -33,12 +33,12 @@ int free(int argc, char **argv) {
 	}
 	char *ptr;
 	uint32_t addr = strtol(argv[1], &ptr, 0);
-	if (*ptr != 0) {
+	if (*ptr != 0 || argv[1][0] == '-') {
 		kprintf(BLTNAME ": Address not well formatted.\n");
 		return -1;
 	}
-	size_t size = strtol(argv[2], &ptr, 0);
-	if (*ptr != 0) {
+	int32_t size = strtol(argv[2], &ptr, 0);
+	if (*ptr != 0 || size < 0) {
 		kprintf(BLTNAME ": Size not well formatted.\n");
 		return -1;
 	}

--- a/kernel/nsh/builtins/info.c
+++ b/kernel/nsh/builtins/info.c
@@ -137,7 +137,7 @@ int info(int argc, char **argv) {
 			char *ptr;
 			int order = strtol(argv[2], &ptr, 0);
 			if (*ptr || order < 0 || order >= KPM_NORDERS) {
-				kprintf(BLTNAME ": order number wrong.\n");
+				kprintf(BLTNAME ": order number not formatted correctly\n");
 				return -1;
 			}
 			info_buddy(order);

--- a/kernel/nsh/builtins/info.c
+++ b/kernel/nsh/builtins/info.c
@@ -6,13 +6,15 @@
  * Info builtin file
  *
  * created: 2022/12/09 - mrxx0 <chcoutur@student.42.fr>
- * updated: 2022/12/15 - glafond- <glafond-@student.42.fr>
+ * updated: 2022/12/17 - xlmod <glafond-@student.42.fr>
  */ 
 
 #include <stdint.h>
 #include <kernel/print.h>
 #include <kernel/string.h>
 #include <kernel/kpm.h>
+#include <kernel/screenbuf.h>
+#include <kernel/stdlib.h>
 
 #include "../../gdt_internal.h"
 #include "../../idt_internal.h"
@@ -25,6 +27,8 @@ extern void *stack_top;
 extern buddy_t *buddy;
 extern t_idt_entry idt[256];
 extern t_idt_ptr idtp;
+
+extern struct screenbuf *sb_current;
 
 #define PRINT(reg, var, format) \
 	reg(var); kprintf(format, var)
@@ -62,13 +66,39 @@ static void info_idt() {
 	kprintf("Size = %u bytes\n", sizeof(idt));	
 }
 
-static void info_buddy() {
+static void info_buddy_print_order(int order) {
+	uint8_t oldcolor = sb_get_color(sb_current);
+	kprintf("order %u(size of %u)\n", order, buddy->orders[order].size);
+	for (size_t i = 0; i < buddy->orders[order].size; i++) {
+		if (i % 32 == 0) {
+			kprintf("\n%4x  ", i);
+		}
+		bitmap_t val = buddy->orders[order].bitmap[i];
+		if (val == 0) {
+			sb_set_bg(sb_current, SB_COLOR_WHITE);
+			kprintf("  ");
+		} else if (val == 0xff) {
+			sb_set_bg(sb_current, SB_COLOR_RED);
+			kprintf("  ");
+		} else {
+			sb_set_bg(sb_current, SB_COLOR_BROWN);
+			kprintf("%2x", val);
+		}
+		sb_set_color(sb_current, oldcolor);
+	}
+	sb_set_color(sb_current, oldcolor);
+	kprintf("\n");
+}
+
+static void info_buddy(int order) {
 	kprintf("INFO BUDDY\n");
 	kprintf("buddy address:        %p\n", buddy);
 	kprintf("buddy size:           %u KB\n", buddy->size / 1024);
 	kprintf("orders address:       %p\n", buddy->orders[0].bitmap);
 	kprintf("frame number:         %x\n", buddy->nframes);
-	kprintf("memory size:          %u KB\n\n", buddy->nframes << 2);
+	kprintf("memory size:          %u KB\n", buddy->nframes << 2);
+	if (order >= 0)
+		info_buddy_print_order(order);
 }
 
 static void info_stack() {
@@ -103,7 +133,17 @@ int info(int argc, char **argv) {
 	} else if (!strcmp(argv[1], "stack")) {
 		info_stack();
 	} else if (!strcmp(argv[1], "buddy")) {
-		info_buddy();
+		if (argc > 2) {
+			char *ptr;
+			int order = strtol(argv[2], &ptr, 0);
+			if (*ptr || order < 0 || order >= KPM_NORDERS) {
+				kprintf(BLTNAME ": order number wrong.\n");
+				return -1;
+			}
+			info_buddy(order);
+		} else {
+			info_buddy(-1);
+		}
 	} else if (!strcmp(argv[1], "idt")) {
 		info_idt();
 	} else if (!strcmp(argv[1], "registers")) {


### PR DESCRIPTION
In bitmap_ffu, use a bitmap_t(uint8_t) variable to get the inverted byte and call __builtin_ffs.
The old way used a pointer and called `__builtin_ffs(~*cur)` that casted the value in 32bit so the __builtin_ffs returned a index bigger than the number of blocks.

Add to info buddy a optional arg to print the order.

Reset the color in alloc when allocation failed.

Closes #48 